### PR TITLE
Use the right URL to go to Meetup

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 # Activities
 [![twitter badge](https://img.shields.io/twitter/follow/asturiasjs?style=social)](https://twitter.com/asturiasjs)
-[![meetup badge](https://img.shields.io/badge/meetup-asturias.js-%23ED1C40?logo=meetup&style=social)](https://twitter.com/asturiasjs)
+[![meetup badge](https://img.shields.io/badge/meetup-asturias.js-%23ED1C40?logo=meetup&style=social)](https://meetup.com/asturias-javascript)
 
-¿Quieres proponer una charla, taller, hackathon, debate, etc? [Abre una issue](https://github.com/asturiasjs/activities/issues/new) y cuéntanos tu propuesta 🙋.
+¿Quieres proponer una charla, taller, hackathon, debate, etc? [Abre una issue](https://github.com/asturiasjs/activities/issues/new) y cuéntanos tu propuesta ✨
 
 ## Sobre asturias.js
 


### PR DESCRIPTION
We were using Twitter's URL for both: meetup and twitter 😅 