### PR TITLE
Add issue config.yml

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false


### PR DESCRIPTION
Parece que GitHub ahora permite evitar que se creen issues sin utilizar las plantillas, ¿os parece que lo habilitemos?

También podríamos añadir otras formas de contacto, no se si nos puede interesar, pero dejo [el link a la documentación](https://help.github.com/en/github/building-a-strong-community/configuring-issue-templates-for-your-repository#configuring-the-template-chooser) para que echéis un vistazo.