### PR TITLE
Add Twitter as contact link

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Twitter
-    url: https://twitter.com/asturiasjs
+    url: https://twitter.com/messages/compose?recipient_id=1253390266943385604
     about: Cualquier duda o consulta puedes mandarnos un DM por Twitter


### PR DESCRIPTION
Como comentaba en #6 con esta configuración podemos dar la opción de Twitter como forma de contacto en el selector de plantilla de issues.

[Documentación de issues en GitHub](https://help.github.com/en/github/building-a-strong-community/configuring-issue-templates-for-your-repository#configuring-the-template-chooser)